### PR TITLE
DAT-15863      DevOps :: liquibase-git-resource extension actions failing

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.4.0
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.4.4
     secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.4.0
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.4.4
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.4.0
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.4.4
     secrets: inherit

--- a/.github/workflows/synk-nightly.yml
+++ b/.github/workflows/synk-nightly.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   security-scan:
-    uses: liquibase/build-logic/.github/workflows/synk-nightly.yml@v0.4.0
+    uses: liquibase/build-logic/.github/workflows/synk-nightly.yml@v0.4.4
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-test:
-      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.4.0
+      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.4.4
       secrets: inherit
       with:
         java: '[11, 17, 18]'


### PR DESCRIPTION
chore(workflows): update liquibase/build-logic workflows to v0.4.4

The liquibase/build-logic workflows have been updated to version v0.4.4. This update includes bug fixes and improvements to the workflows. The following workflows have been updated:

- attach-artifact-release.yml
- create-release.yml
- release-published.yml
- synk-nightly.yml
- test.yml