### PR TITLE
Fix random concurrency issue

### DIFF
--- a/src/main/java/org/liquibase/ext/resource/git/GitPathHandler.java
+++ b/src/main/java/org/liquibase/ext/resource/git/GitPathHandler.java
@@ -72,7 +72,9 @@ public class GitPathHandler extends AbstractPathHandler {
             } catch (GitAPIException | JGitInternalException e) {
                 throw new IOException(e.getMessage());
             } finally {
-                repository.close();
+                if (repository != null) {
+                    repository.close();
+                }
                 Git.shutdown();
             }
             Scope.getCurrentScope().getLog(GitPathHandler.class).fine("Return DirectoryResourceAccessor for root path " + path);

--- a/src/main/java/org/liquibase/ext/resource/git/GitPathHandler.java
+++ b/src/main/java/org/liquibase/ext/resource/git/GitPathHandler.java
@@ -52,11 +52,11 @@ public class GitPathHandler extends AbstractPathHandler {
             if (!path.exists()) {
                 path.mkdirs();
             }
+            Repository repository = null;
             try {
                 RepositoryBuilder repositoryBuilder = new RepositoryBuilder().setGitDir(gitPath);
-                Repository repository = repositoryBuilder.build();
+                repository = repositoryBuilder.build();
                 if (repository.getObjectDatabase().exists()) {
-                    repository.close();
                     Git git = Git.open(path);
                     if (branch != null && !branch.isEmpty()) {
                         git.checkout().setName(branch).call();
@@ -72,6 +72,7 @@ public class GitPathHandler extends AbstractPathHandler {
             } catch (GitAPIException | JGitInternalException e) {
                 throw new IOException(e.getMessage());
             } finally {
+                repository.close();
                 Git.shutdown();
             }
             Scope.getCurrentScope().getLog(GitPathHandler.class).fine("Return DirectoryResourceAccessor for root path " + path);


### PR DESCRIPTION
Occasionally when re-running the git extension with an already existing repo, this error could occur:
```
Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@5f2c773b[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@5e5be0aa[Wrapped task = org.eclipse.jgit.lib.RepositoryCache$$Lambda$933/0x00007fd8e7618430@3e55a0a6]] rejected from java.util.concurrent.ScheduledThreadPoolExecutor@1e97af5a[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 1]
```
Re-ordering and putting repository.close() in the finally clause fixes it. 